### PR TITLE
Fix punchline formatting in JokeContentWithFavoritesPreview

### DIFF
--- a/app/src/main/java/io/devexpert/dailyjoke/presentation/screen/JokeScreen.kt
+++ b/app/src/main/java/io/devexpert/dailyjoke/presentation/screen/JokeScreen.kt
@@ -506,7 +506,7 @@ private fun JokeContentWithFavoritesPreview() {
         JokeContent(
             joke = Joke(
                 setup = "Why don't scientists trust atoms?",
-                punchline = "Because they make up everything!!!",
+                punchline = "Because they make up everything!",
                 category = "Science"
             ),
             favorites = listOf(


### PR DESCRIPTION
## Summary
- Fixed inconsistent formatting in `JokeContentWithFavoritesPreview` where the punchline had triple exclamation marks (`!!!`) instead of single exclamation mark (`!`)
- Ensures consistency with other preview functions in the same file

## Changes Made
- Changed `"Because they make up everything!!!"` to `"Because they make up everything!"`
- Location: `JokeScreen.kt:509`

## Test Plan
- [x] Verified the change maintains preview functionality
- [x] Confirmed consistency with other preview functions
- [x] No functional impact on the app behavior

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)